### PR TITLE
Feature: research and implement Semantic Answer Similarity.

### DIFF
--- a/lm_eval/api/metrics.py
+++ b/lm_eval/api/metrics.py
@@ -9,7 +9,7 @@ import numpy as np
 import sacrebleu
 import sklearn.metrics
 
-from sentence_transformers import SentenceTransformer
+from sentence_transformers import SentenceTransformer, CrossEncoder
 
 from lm_eval.api.registry import register_aggregation, register_metric
 
@@ -208,7 +208,7 @@ def sas_cross_encoder(**kwargs):
         sas_cross_encoder.loaded_models = {}
     model_name_or_path = kwargs["model_name_or_path"]
     if model_name_or_path not in sas_encoder.loaded_models:
-        sas_cross_encoder.loaded_models[model_name_or_path] = SentenceTransformer(model_name_or_path)
+        sas_cross_encoder.loaded_models[model_name_or_path] = CrossEncoder(model_name_or_path)
     sas_model = sas_cross_encoder.loaded_models[model_name_or_path]
     return model.predict(kwargs["predictions"]+kwargs["references"])
     

--- a/lm_eval/api/metrics.py
+++ b/lm_eval/api/metrics.py
@@ -9,6 +9,8 @@ import numpy as np
 import sacrebleu
 import sklearn.metrics
 
+from sentence_transformers import SentenceTransformer
+
 from lm_eval.api.registry import register_aggregation, register_metric
 
 
@@ -177,6 +179,24 @@ exact_match = hf_evaluate.load("exact_match")
 def exact_match_fn(**kwargs):
     return exact_match.compute(**kwargs)
 
+
+@register_metric(
+    metric="sas_encoder",
+    higher_is_better=True,
+    output_type="generate_until",
+    aggregation="mean",
+)
+def sas_encoder(**kwargs):
+    if "loaded_models" not in sas_encoder.__dict__:
+        sas_encoder.loaded_models = {}
+    model_name_or_path = kwargs["model_name_or_path"]
+    if model_name_or_path not in sas_encoder.loaded_models:
+        sas_encoder.loaded_models[model_name_or_path] = SentenceTransformer(model_name_or_path)
+    model = sas_encoder.loaded_models[model_name_or_path]
+    preds = model.encode(kwargs["predictions"])[0]
+    refs = model.encode(kwargs["references"])[0]
+    return np.dot(refs, preds)/(np.linalg.norm(preds)*np.linalg.norm(refs))
+    
 
 @register_metric(
     metric="perplexity",

--- a/lm_eval/api/metrics.py
+++ b/lm_eval/api/metrics.py
@@ -192,10 +192,25 @@ def sas_encoder(**kwargs):
     model_name_or_path = kwargs["model_name_or_path"]
     if model_name_or_path not in sas_encoder.loaded_models:
         sas_encoder.loaded_models[model_name_or_path] = SentenceTransformer(model_name_or_path)
-    model = sas_encoder.loaded_models[model_name_or_path]
-    preds = model.encode(kwargs["predictions"])[0]
-    refs = model.encode(kwargs["references"])[0]
+    sas_model = sas_encoder.loaded_models[model_name_or_path]
+    preds = sas_model.encode(kwargs["predictions"])[0]
+    refs = sas_model.encode(kwargs["references"])[0]
     return np.dot(refs, preds)/(np.linalg.norm(preds)*np.linalg.norm(refs))
+
+@register_metric(
+    metric="sas_cross_encoder",
+    higher_is_better=True,
+    output_type="generate_until",
+    aggregation="mean",
+)
+def sas_cross_encoder(**kwargs):
+    if "loaded_models" not in sas_encoder.__dict__:
+        sas_cross_encoder.loaded_models = {}
+    model_name_or_path = kwargs["model_name_or_path"]
+    if model_name_or_path not in sas_encoder.loaded_models:
+        sas_cross_encoder.loaded_models[model_name_or_path] = SentenceTransformer(model_name_or_path)
+    sas_model = sas_cross_encoder.loaded_models[model_name_or_path]
+    return model.predict(kwargs["predictions"]+kwargs["references"])
     
 
 @register_metric(

--- a/lm_eval/api/metrics.py
+++ b/lm_eval/api/metrics.py
@@ -204,10 +204,10 @@ def sas_encoder(**kwargs):
     aggregation="mean",
 )
 def sas_cross_encoder(**kwargs):
-    if "loaded_models" not in sas_encoder.__dict__:
+    if "loaded_models" not in sas_cross_encoder.__dict__:
         sas_cross_encoder.loaded_models = {}
     model_name_or_path = kwargs["model_name_or_path"]
-    if model_name_or_path not in sas_encoder.loaded_models:
+    if model_name_or_path not in sas_cross_encoder.loaded_models:
         sas_cross_encoder.loaded_models[model_name_or_path] = CrossEncoder(model_name_or_path)
     sas_model = sas_cross_encoder.loaded_models[model_name_or_path]
     return model.predict(kwargs["predictions"]+kwargs["references"])

--- a/lm_eval/api/metrics.py
+++ b/lm_eval/api/metrics.py
@@ -210,7 +210,7 @@ def sas_cross_encoder(**kwargs):
     if model_name_or_path not in sas_cross_encoder.loaded_models:
         sas_cross_encoder.loaded_models[model_name_or_path] = CrossEncoder(model_name_or_path)
     sas_model = sas_cross_encoder.loaded_models[model_name_or_path]
-    return model.predict(kwargs["predictions"]+kwargs["references"])
+    return sas_model.predict(kwargs["predictions"]+kwargs["references"])
     
 
 @register_metric(

--- a/lm_eval/tasks/aquas/README.md
+++ b/lm_eval/tasks/aquas/README.md
@@ -4,34 +4,38 @@
 
 Title: `Abstractive Question Answering in Spanish (AQuAS)`
 
-Abstract: `link to paper PDF or arXiv abstract goes here`
+AQuAS es un dataset de alta calidad realizado de forma manual por dos lingüistas computacionales con el fin de evaluar modelos de lenguaje en la tarea de Question-Answering Abstractivo en español.
 
-`Short description of paper / benchmark goes here:`
-
-Homepage: `homepage to the benchmark's website goes here, if applicable`
+Homepage: https://huggingface.co/datasets/IIC/AQuAS
 
 
 ### Citation
 
 ```
-BibTeX-formatted citation goes here
+@misc {Instituto de Ingeniería del Conocimiento (IIC),
+    author       = { {Instituto de Ingeniería del Conocimiento} },
+    title        = { Abstractive Question-Answering in Spanish (AQuAS) Dataset },
+    year         = 2024,
+    url          = { https://huggingface.co/datasets/IIC/AQuAS },
+    doi          = { 10.57967/hf/2043 },
+    publisher    = { Hugging Face }
+}
 ```
 
 ### Groups and Tasks
 
 #### Groups
 
-* `group_name`: `Short description`
+* Open Spanish LLM Leaderboard
 
 #### Tasks
 
-* `task_name`: `1-sentence description of what this particular task does`
-* `task_name2`: ...
+* `aquas`
 
 ### Checklist
 
 For adding novel benchmarks/datasets to the library:
-* [ ] Is the task an existing benchmark in the literature?
+* [x] Is the task an existing benchmark in the literature?
   * [ ] Have you referenced the original paper that introduced the task?
   * [ ] If yes, does the original paper provide a reference implementation? If so, have you checked against the reference implementation and documented how to run such a test?
 

--- a/lm_eval/tasks/aquas/README.md
+++ b/lm_eval/tasks/aquas/README.md
@@ -1,4 +1,4 @@
-# aquas
+# AQuAS
 
 ### Paper
 

--- a/lm_eval/tasks/aquas/README.md
+++ b/lm_eval/tasks/aquas/README.md
@@ -4,7 +4,9 @@
 
 Title: `Abstractive Question Answering in Spanish (AQuAS)`
 
-AQuAS es un dataset de alta calidad realizado de forma manual por dos lingüistas computacionales con el fin de evaluar modelos de lenguaje en la tarea de Question-Answering Abstractivo en español.
+`EN:` AQuAS is a high-quality dataset manually created by two computational linguists with the objective of evaluating language models on the Abstractive Question-Answering task in Spanish.
+
+`ES:` AQuAS es un dataset de alta calidad realizado de forma manual por dos lingüistas computacionales con el fin de evaluar modelos de lenguaje en la tarea de Question-Answering Abstractivo en español.
 
 Homepage: https://huggingface.co/datasets/IIC/AQuAS
 

--- a/lm_eval/tasks/aquas/README.md
+++ b/lm_eval/tasks/aquas/README.md
@@ -1,0 +1,42 @@
+# aquas
+
+### Paper
+
+Title: `Abstractive Question Answering in Spanish (AQuAS)`
+
+Abstract: `link to paper PDF or arXiv abstract goes here`
+
+`Short description of paper / benchmark goes here:`
+
+Homepage: `homepage to the benchmark's website goes here, if applicable`
+
+
+### Citation
+
+```
+BibTeX-formatted citation goes here
+```
+
+### Groups and Tasks
+
+#### Groups
+
+* `group_name`: `Short description`
+
+#### Tasks
+
+* `task_name`: `1-sentence description of what this particular task does`
+* `task_name2`: ...
+
+### Checklist
+
+For adding novel benchmarks/datasets to the library:
+* [ ] Is the task an existing benchmark in the literature?
+  * [ ] Have you referenced the original paper that introduced the task?
+  * [ ] If yes, does the original paper provide a reference implementation? If so, have you checked against the reference implementation and documented how to run such a test?
+
+
+If other tasks on this dataset are already supported:
+* [ ] Is the "Main" variant of this task clearly denoted?
+* [ ] Have you provided a short sentence in a README on what each new variant adds / evaluates?
+* [ ] Have you noted which, if any, published evaluation setups are matched by this variant?

--- a/lm_eval/tasks/aquas/aquas.yaml
+++ b/lm_eval/tasks/aquas/aquas.yaml
@@ -1,7 +1,5 @@
 task: aquas
 dataset_path: IIC/AQuAS
-training_split: null
-validation_split: test
 test_split: test
 doc_to_text: "Responde a la pregunta utilizando únicamente el contexto proporcionado.\n\nContexto:\n{{context}}\n\nPregunta:\n{{question}}\n\nRespuesta:\n"
 doc_to_target: "{{answer}}"

--- a/lm_eval/tasks/aquas/aquas.yaml
+++ b/lm_eval/tasks/aquas/aquas.yaml
@@ -1,0 +1,14 @@
+task: aquas
+dataset_path: IIC/AQuAS
+training_split: null
+validation_split: test
+test_split: test
+doc_to_text: "Dado el siguiente contexto\n\n{{context}}\n\nResponde a esta pregunta:\n\n{{question}}"
+doc_to_target: "{{answer}}"
+metric_list:
+  - metric: sas_encoder
+    model_name_or_path: "BAAI/bge-m3"
+    aggregation: mean
+    higher_is_better: true
+metadata:
+  version: 0

--- a/lm_eval/tasks/aquas/aquas.yaml
+++ b/lm_eval/tasks/aquas/aquas.yaml
@@ -3,7 +3,7 @@ dataset_path: IIC/AQuAS
 training_split: null
 validation_split: test
 test_split: test
-doc_to_text: "Dado el siguiente contexto\n\n{{context}}\n\nResponde a esta pregunta:\n\n{{question}}"
+doc_to_text: "Responde a la pregunta utilizando únicamente el contexto proporcionado.\n\nContexto:\n{{context}}\n\nPregunta:\n{{question}}\n\nRespuesta:\n"
 doc_to_target: "{{answer}}"
 metric_list:
   - metric: sas_encoder
@@ -11,7 +11,7 @@ metric_list:
     aggregation: mean
     higher_is_better: true
   - metric: sas_cross_encoder
-    model_name_or_path: "cross-encoder/stsb-roberta-base"
+    model_name_or_path: "BAAI/bge-reranker-v2-m3"
     aggregation: mean
     higher_is_better: true
 metadata:

--- a/lm_eval/tasks/aquas/aquas.yaml
+++ b/lm_eval/tasks/aquas/aquas.yaml
@@ -10,5 +10,9 @@ metric_list:
     model_name_or_path: "BAAI/bge-m3"
     aggregation: mean
     higher_is_better: true
+  - metric: sas_cross_encoder
+    model_name_or_path: "cross-encoder/stsb-roberta-base"
+    aggregation: mean
+    higher_is_better: true
 metadata:
   version: 0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ dependencies = [
     "torch>=1.8",
     "tqdm-multiprocess",
     "transformers>=4.1",
+    "sentence-transformers>=2.7",
     "zstandard",
     "dill",
     "word2number",


### PR DESCRIPTION
`biencoder_sas`: to compute SAS using a text encoder and the cosine similarity. The scores are between -1 and 1.
`cross_encoder_sas`: to compute SAS using a cross-encoder. The scores are between 0 and 1.
`aquas`: new task to evaluate models in the abstractive question-answering task in spanish using these two new metrics.