### PR TITLE
feat: change deprecated function in utils.py

### DIFF
--- a/lm_eval/tasks/basqueglue/utils.py
+++ b/lm_eval/tasks/basqueglue/utils.py
@@ -1,7 +1,7 @@
 import html
 import re
 
-from datasets import load_metric
+import evaluate
 
 
 def general_detokenize(string):
@@ -60,7 +60,7 @@ def coref_doc_to_text(x):
 
 
 def micro_f1_score(items):
-    f1_metric = load_metric("f1")
+    f1_metric = evaluate.load("f1")
     golds, preds = list(zip(*items))
     f1_score = f1_metric.compute(references=golds, predictions=preds, average="micro")[
         "f1"
@@ -69,7 +69,7 @@ def micro_f1_score(items):
 
 
 def vaxx_f1_score(items):
-    f1_metric = load_metric("f1")
+    f1_metric = evaluate.load("f1")
     golds, preds = list(zip(*items))
     f1_class = f1_metric.compute(
         references=golds, predictions=preds, labels=[0, 2], average=None


### PR DESCRIPTION
https://github.com/huggingface/datasets/releases

Dede la 3.0.0 han eliminado esta función. Al instalar la librería, justo se te pone esta última release por cómo está configurado el pyproject, entonces al evaluar un modelo salta este error:

ImportError: cannot import name 'load_metric' from 'datasets'