### PR TITLE
Adds few-shot samples for bertaqa and eus_trivia.

### DIFF
--- a/lm_eval/tasks/bertaqa/bertaqa_en.yaml
+++ b/lm_eval/tasks/bertaqa/bertaqa_en.yaml
@@ -2,3 +2,6 @@ task: bertaqa_en
 include: _bertaqa_template
 dataset_name: en
 doc_to_text: "Question: {{question}}\nA: {{candidates[0]}}\nB: {{candidates[1]}}\nC: {{candidates[2]}}\nAnswer:"
+fewshot_config:
+  sampler: first_n
+  samples: !function utils.list_fewshot_samples(dataset_name)

--- a/lm_eval/tasks/bertaqa/bertaqa_eu.yaml
+++ b/lm_eval/tasks/bertaqa/bertaqa_eu.yaml
@@ -2,3 +2,6 @@ task: bertaqa_eu
 include: _bertaqa_template
 dataset_name: eu
 doc_to_text: "Galdera: {{question}}\nA: {{candidates[0]}}\nB: {{candidates[1]}}\nC: {{candidates[2]}}\nErantzuna:"
+fewshot_config:
+  sampler: first_n
+  samples: !function utils.list_fewshot_samples(dataset_name)

--- a/lm_eval/tasks/bertaqa/utils.py
+++ b/lm_eval/tasks/bertaqa/utils.py
@@ -1,0 +1,37 @@
+def list_fewshot_samples() -> dict[str, list[dict]]:
+    return {
+        "bertaqa_en": [
+            {
+            "problem": "Question: Who was imprisoned in 1964?\nA: Nelson Mandela\nB: Mumia Abu Jamal\nC: Charles Ghankay\nAnswer:",
+            "solution": "Nelson Mandela",
+            "few-shot": "1"
+},
+            {
+            "problem": "Question: What's the name of the film based on Bernardo Atxaga's novel \"Obabakoak\"?\nA: \"Obabakoak\"\nB: \"Obaba\"\nC: \"Obabako istorioak\"\nAnswer:",
+            "solution": "\"Obaba\"",
+            "few-shot": "1"
+},
+            {
+            "problem": "Question: How long, more or less, did the episodes of \"Bertan zoro\" last?\nA: 90 minutes\nB: 60 minutes\nC: 30 minutes\nAnswer:",
+            "solution": "30 minutes",
+            "few-shot": "1"
+},
+        ],
+        "bertaqa_eu": [
+            {
+            "problem": "Galdera: Nor kartzelaratu zuten 1964an?\nA: Nelson Mandela\nB: Mumia Abu Jamal\nC: Charles Ghankay\nErantzuna:",
+            "solution": "Nelson Mandela",
+            "few-shot": "1"
+},
+            {
+            "problem": "Galdera: Nola du izena Bernardo Atxagaren \"Obabakoak\" eleberrian oinarritutako filmak?\nA: \"Obabakoak\"\nB: \"Obaba\"\nC: \"Obabako istorioak\"\nErantzuna:",
+            "solution": "\"Obaba\"",
+            "few-shot": "1"
+},
+            {
+            "problem": "Galdera: Zenbat irauten zuten, gutxi gorabehera, \"Bertan zoro\" telesaileko kapituluek?\nA: 90 minutu\nB: Ordubete\nC: 30 minutu\nErantzuna:",
+            "solution": "30 minutu",
+            "few-shot": "1"
+},
+        ],
+    }

--- a/lm_eval/tasks/eus_trivia/eus_trivia.yaml
+++ b/lm_eval/tasks/eus_trivia/eus_trivia.yaml
@@ -15,3 +15,6 @@ metric_list:
     higher_is_better: true
 metadata:
   version: 0.0
+fewshot_config:
+  sampler: first_n
+  samples: !function utils.list_fewshot_samples

--- a/lm_eval/tasks/eus_trivia/utils.py
+++ b/lm_eval/tasks/eus_trivia/utils.py
@@ -39,3 +39,27 @@ def doc_to_choice(doc) -> List[str]:
     if num_choices < 2:
         raise ValueError("Invalid number of candidates")
     return letters[:num_choices]
+
+def list_fewshot_samples() -> list[dict]:
+    return [
+        {
+        "problem": "Galdera: Nola bota behar dira honakoak ontzi horietara?\nA: Apurturik\nB: Denak lotuta\nC: Tapoia kendu gabe\nD: Tapoirik gabe\nErantzuna:",
+        "solution": "Tapoirik gabe",
+        "few-shot": "1"
+},
+        {
+        "problem": "Galdera: Zein da 69 zenbakiaren hurrengoa?\nA: 96\nB: 86\nC: 70\nC: 68\nErantzuna:",
+        "solution": "70",
+        "few-shot": "1"
+},
+        {
+        "problem": "Galdera: Lau sagarrek 400 gr pisatzen badute, zenbat pisatzen du sagar batek?\nA: Ez dakigu\nB: 150 gr\nC: 75 gr\nD: 100 gr\nErantzuna:",
+        "solution": "Ez dakigu",
+        "few-shot": "1"
+},
+        {
+        "problem": "Galdera: Zein da Bizkaian topa dezakegun sugerik handiena?\nA: Boa sugea\nB: Eskolapioren sugea\nC: Sugegorria\nD: Zirauna\nErantzuna:",
+        "solution": "Eskolapioren sugea",
+        "few-shot": "1"
+},
+    ]


### PR DESCRIPTION
1. Modifica el utils.py de eus_trivia, añadiendo la función que incluye los ejemplos y el YAML, que llama a utils.py.

2. Añade un utils.py para bertaqa, añadiendo la función que incluye los ejemplos y los YAML, que llama a utils.py. En este caso, la función con los ejemplos necesita de un argumento, el nombre de la task, que se coge del "dataset_name" en el YAML.