### PR TITLE
Update bertaqa_eu.yaml

### DIFF
--- a/lm_eval/tasks/bertaqa/bertaqa_eu.yaml
+++ b/lm_eval/tasks/bertaqa/bertaqa_eu.yaml
@@ -4,4 +4,4 @@ dataset_name: eu
 doc_to_text: "Galdera: {{question}}\nA: {{candidates[0]}}\nB: {{candidates[1]}}\nC: {{candidates[2]}}\nErantzuna:"
 fewshot_config:
   sampler: first_n
-  samples: !function utils.list_fewshot_samples(dataset_name)
+  samples: !function utils.list_fewshot_samples


### PR DESCRIPTION
Delete argument for dataset processing function.

When I tried to load dataset through TaskManager:
```python
from lm_eval.tasks import TaskManager
task_manager = TaskManager('INFO')
task_manager.load_task_or_group("bertaqa_eu")
```
I got error since it couldn't import utils.list_fewshot_samples.
When I deleted argument I loaded task successfully.